### PR TITLE
Remove obsolete dependency

### DIFF
--- a/library.json
+++ b/library.json
@@ -26,11 +26,6 @@
       "machineName": "H5P.Question",
       "majorVersion": 1,
       "minorVersion": 4
-    },
-    {
-      "machineName": "H5P.JoubelUI",
-      "majorVersion": 1,
-      "minorVersion": 3
     }
   ]
 }


### PR DESCRIPTION
The dependency to H5P.JoubelUI is already taken care of by H5P.Question, see (https://github.com/h5p/h5p-boilerplate/issues/27)